### PR TITLE
Grid auf Infoseite

### DIFF
--- a/demostatapp/templates/demostatapp/components/demo_card.html
+++ b/demostatapp/templates/demostatapp/components/demo_card.html
@@ -2,7 +2,7 @@
   <div class="card-body">
     <h5 class="card-title">{{ demo.title }} <small class="text-muted">von <a href="{% url 'demostatapp:organisation' demo.organisation.slug %}">{{ demo.organisation.name }}</a></small></h5>
     <h6 class="card-subtitle mb-2 text-muted">{{ demo.date|date:"d.m.Y H:i" }} Uhr, {{ demo.location.name }}</h6>
-    <p class="card-text">{{ demo.description | truncatewords:50 }}</p>
+    <p class="card-text">{{ demo.description }}</p>
     <p>
       {% for tag in demo.tags.all %}<a href="{% url 'demostatapp:tag' tag.slug %}" class="badge badge-light mr-2">{{ tag.name }}</a>{% endfor %}
     </p>

--- a/demostatapp/templates/demostatapp/components/demo_card.html
+++ b/demostatapp/templates/demostatapp/components/demo_card.html
@@ -2,7 +2,7 @@
   <div class="card-body">
     <h5 class="card-title">{{ demo.title }} <small class="text-muted">von <a href="{% url 'demostatapp:organisation' demo.organisation.slug %}">{{ demo.organisation.name }}</a></small></h5>
     <h6 class="card-subtitle mb-2 text-muted">{{ demo.date|date:"d.m.Y H:i" }} Uhr, {{ demo.location.name }}</h6>
-    <p class="card-text">{{ demo.description }}</p>
+    <p class="card-text">{{ demo.description | truncatewords:50 }}</p>
     <p>
       {% for tag in demo.tags.all %}<a href="{% url 'demostatapp:tag' tag.slug %}" class="badge badge-light mr-2">{{ tag.name }}</a>{% endfor %}
     </p>

--- a/demostatapp/templates/demostatapp/components/demo_card.html
+++ b/demostatapp/templates/demostatapp/components/demo_card.html
@@ -4,7 +4,7 @@
     <h6 class="card-subtitle mb-2 text-muted">{{ demo.date|date:"d.m.Y H:i" }} Uhr, {{ demo.location.name }}</h6>
     <p class="card-text">{{ demo.description }}</p>
     <p>
-      {% for tag in demo.tags.all %}<a href="{% url 'demostatapp:tag' tag.slug %}" class="badge badge-light">{{ tag.name }}</a>{% endfor %}
+      {% for tag in demo.tags.all %}<a href="{% url 'demostatapp:tag' tag.slug %}" class="badge badge-light mr-2">{{ tag.name }}</a>{% endfor %}
     </p>
     <a href="{% url 'demostatapp:demo' demo.date|date:"Y" demo.date|date:"m" demo.date|date:"d" demo.slug %}" class="btn btn-primary card-link">Mehr Details</a> {% for link in demo.link_set.all|slice:":4" %}<a href="{{ link.url }}" class="card-link">{{ link.title }}</a> {% endfor %}
   </div>

--- a/demostatapp/templates/demostatapp/components/demo_card_list.html
+++ b/demostatapp/templates/demostatapp/components/demo_card_list.html
@@ -6,13 +6,9 @@
 {% for day, demos in demo_list_date %}
 <section id="{{ day|date:"d" }}">
   <h3 class="title">{% if day|date:"d.m.Y" == today %}Heute{% else %}{{ day|date:"l, d.m.Y" }}{% endif %}</h3>
-  <div class="row">
-    {% for demo in demos %}
-    <div class="col-12 col-md-6 col-lg-4">
-      {% include "demostatapp/components/demo_card.html" %}
-    </div>
-    {% endfor %}
-  </div>
+  {% for demo in demos %}
+  {% include "demostatapp/components/demo_card.html" %}
+  {% endfor %}
 </section>
 {% endfor %}
 {% else %}

--- a/demostatapp/templates/demostatapp/components/demo_card_list.html
+++ b/demostatapp/templates/demostatapp/components/demo_card_list.html
@@ -6,9 +6,13 @@
 {% for day, demos in demo_list_date %}
 <section id="{{ day|date:"d" }}">
   <h3 class="title">{% if day|date:"d.m.Y" == today %}Heute{% else %}{{ day|date:"l, d.m.Y" }}{% endif %}</h3>
-  {% for demo in demos %}
-  {% include "demostatapp/components/demo_card.html" %}
-  {% endfor %}
+  <div class="row">
+    {% for demo in demos %}
+    <div class="col-12 col-md-6 col-lg-4">
+      {% include "demostatapp/components/demo_card.html" %}
+    </div>
+    {% endfor %}
+  </div>
 </section>
 {% endfor %}
 {% else %}

--- a/demostatapp/templates/demostatapp/demo_detail.html
+++ b/demostatapp/templates/demostatapp/demo_detail.html
@@ -6,7 +6,7 @@
 <h1 class="display-4">{{ demo.title }} am {{ demo.date|date:"d.m.Y" }}</h1>
 <section class="tags">
   <span class="h3">
-    {% for tag in demo.tags.all %}<a href="{% url 'demostatapp:tag' tag.slug %}" class="badge badge-light">{{ tag.name }}</a>{% endfor %}
+    {% for tag in demo.tags.all %}<a href="{% url 'demostatapp:tag' tag.slug %}" class="badge badge-light mr-2">{{ tag.name }}</a>{% endfor %}
   </span>
 </section>
 {% endblock%}
@@ -36,7 +36,7 @@
   <div class="card">
     <div class="card-body">
       <h5 class="card-title">Was?</h5>
-      <p class="card-text">{{ demo.description }}</p>
+      <p class="card-text">{{ demo.description | linebreaks }}</p>
     </div>
   </div>
   {% if demo.link_set.all %}
@@ -72,7 +72,7 @@
   <div class="card">
     <div class="card-body">
       <h5 class="card-title">Anmerkungen</h5>
-      <p class="card-text">{{ demo.note }}</p>
+      <p class="card-text">{{ demo.note | linebreaks }}</p>
     </div>
   </div>
   {% endif %}

--- a/demostatapp/templates/demostatapp/demo_detail.html
+++ b/demostatapp/templates/demostatapp/demo_detail.html
@@ -12,78 +12,87 @@
 {% endblock%}
 
 {% block content %}
-<section>
-  <div class="card-group">
-    <div class="card {% if demo.is_next %} border-success {% endif %}">
-      <div class="card-body">
-        <h5 class="card-title">Wann?</h5>
-        <p class="card-text">{{ demo.date|date:"d.m.Y H:i" }} Uhr</p>
-      </div>
-    </div>
-    <div class="card {% if demo.is_next %} border-success {% endif %}">
-      <div class="card-body">
-        <h5 class="card-title">Wo?</h5>
-        <p class="card-text">{{ demo.location.name }}</p>
-      </div>
-    </div>
-    <div class="card {% if demo.is_next %} border-success {% endif %}">
-      <div class="card-body">
-        <h5 class="card-title">Wer?</h5>
-        <p class="card-text"><a href="{% url 'demostatapp:organisation' demo.organisation.slug %}">{{ demo.organisation.name }}</a></p>
-      </div>
-    </div>
-  </div>
-  <div class="card">
-    <div class="card-body">
-      <h5 class="card-title">Was?</h5>
-      <p class="card-text">{{ demo.description | linebreaks }}</p>
-    </div>
-  </div>
-  {% if demo.link_set.all %}
-  <div class="list-group list-group-horizontal-md text-center">
-    {% for link in demo.link_set.all|slice:":4" %}
-    <a href="{{ link.url }}" class="list-group-item flex-fill" target="_blank">{{ link.title }}</a>
-    {% endfor %}
-  </div>
-  {% endif %}
-  {% if demo.location.lat and demo.location.lon %}
-  <div class="card ">
-    <div class="embed-responsive embed-responsive-16by9">
-      <iframe class="embed-responsive-item" src="https://www.openstreetmap.org/export/embed.html?bbox={{ demo.location.box_left }}%2C{{ demo.location.box_bottom }}%2C{{ demo.location.box_right }}%2C{{ demo.location.box_top }}&amp;layer=mapnik&amp;marker={{ demo.location.marker_lat }}%2C{{ demo.location.marker_lon }}"></iframe>
-    </div>
-    <div class="list-group list-group-flush">
-      <a href="https://www.openstreetmap.org/?mlat={{ demo.location.marker_lat }}&amp;mlon={{ demo.location.marker_lon }}#map=17/{{ demo.location.marker_lat }}/{{ demo.location.marker_lon }}" class="list-group-item" target="_blank">Große Karte öffnen</a>
-    </div>
-  </div>
-  {% endif %}
-  {% if demo.link_set.all %}
-  <div class="card">
-    <div class="card-body">
-      <h5 class="card-title">Links</h5>
-    </div>
-    <div class="list-group list-group-flush">
-      {% for link in demo.link_set.all %}
-      <a href="{{ link.url }}" class="list-group-item" target="_blank">{{ link.title }}</a>
-      {% endfor %}
-    </div>
-  </div>
-  {% endif %}
-  {% if demo.note %}
-  <div class="card">
-    <div class="card-body">
-      <h5 class="card-title">Anmerkungen</h5>
-      <p class="card-text">{{ demo.note | linebreaks }}</p>
-    </div>
-  </div>
-  {% endif %}
-  <div class="card">
-    <div class="card-body">
-      <h5 class="card-title">Teilen</h5>
-      <div class="input-group">
-        <div class="input-group-prepend">
-          <span class="input-group-text">Permalink</span>
+<section class="row">
+  <div class="col-12">
+    <div class="card-group">
+      <div class="card {% if demo.is_next %} border-success {% endif %}">
+        <div class="card-body">
+          <h5 class="card-title">Wann?</h5>
+          <p class="card-text">{{ demo.date|date:"d.m.Y H:i" }} Uhr</p>
         </div>
-        <input class="form-control" type="text" placeholder="Permalink" value="https://{{ request.get_host }}{% url 'demostatapp:demo_id' demo.pk %}" readonly>
+      </div>
+      <div class="card {% if demo.is_next %} border-success {% endif %}">
+        <div class="card-body">
+          <h5 class="card-title">Wo?</h5>
+          <p class="card-text">{{ demo.location.name }}</p>
+        </div>
+      </div>
+      <div class="card {% if demo.is_next %} border-success {% endif %}">
+        <div class="card-body">
+          <h5 class="card-title">Wer?</h5>
+          <p class="card-text"><a href="{% url 'demostatapp:organisation' demo.organisation.slug %}">{{ demo.organisation.name }}</a></p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="col-12">
+    <div class="card">
+      <div class="card-body">
+        <h5 class="card-title">Was?</h5>
+        <p class="card-text">{{ demo.description | linebreaks }}</p>
+      </div>
+    </div>
+  </div>
+  {% if demo.location.lat and demo.location.lon %}
+  <div class="col-12 col-md-6">
+    <div class="card ">
+      <div class="embed-responsive embed-responsive-16by9">
+        <iframe class="embed-responsive-item" src="https://www.openstreetmap.org/export/embed.html?bbox={{ demo.location.box_left }}%2C{{ demo.location.box_bottom }}%2C{{ demo.location.box_right }}%2C{{ demo.location.box_top }}&amp;layer=mapnik&amp;marker={{ demo.location.marker_lat }}%2C{{ demo.location.marker_lon }}"></iframe>
+      </div>
+      <div class="list-group list-group-flush">
+        <a href="https://www.openstreetmap.org/?mlat={{ demo.location.marker_lat }}&amp;mlon={{ demo.location.marker_lon }}#map=17/{{ demo.location.marker_lat }}/{{ demo.location.marker_lon }}" class="list-group-item" target="_blank">Große Karte öffnen</a>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+  <div class="col-12 col-md-6">
+    <div class="row">
+      {% if demo.link_set.all %}
+      <div class="col-12">
+        <div class="card">
+          <div class="card-body">
+            <h5 class="card-title">Links</h5>
+          </div>
+          <div class="list-group list-group-flush">
+            {% for link in demo.link_set.all %}
+            <a href="{{ link.url }}" class="list-group-item" target="_blank">{{ link.title }}</a>
+            {% endfor %}
+          </div>
+        </div>
+      </div>
+      {% endif %}
+      {% if demo.note %}
+      <div class="col-12">
+        <div class="card">
+          <div class="card-body">
+            <h5 class="card-title">Anmerkungen</h5>
+            <p class="card-text">{{ demo.note | linebreaks }}</p>
+          </div>
+        </div>
+      </div>
+      {% endif %}
+    </div>
+  </div>
+  <div class="col-12">
+    <div class="card">
+      <div class="card-body">
+        <h5 class="card-title">Teilen</h5>
+        <div class="input-group">
+          <div class="input-group-prepend">
+            <span class="input-group-text">Permalink</span>
+          </div>
+          <input class="form-control" type="text" placeholder="Permalink" value="https://{{ request.get_host }}{% url 'demostatapp:demo_id' demo.pk %}" readonly>
+        </div>
       </div>
     </div>
   </div>

--- a/demostatapp/templates/demostatapp/demo_detail.html
+++ b/demostatapp/templates/demostatapp/demo_detail.html
@@ -43,20 +43,31 @@
       </div>
     </div>
   </div>
-  {% if demo.location.lat and demo.location.lon %}
-  <div class="col-12 col-md-6">
-    <div class="card ">
-      <div class="embed-responsive embed-responsive-16by9">
-        <iframe class="embed-responsive-item" src="https://www.openstreetmap.org/export/embed.html?bbox={{ demo.location.box_left }}%2C{{ demo.location.box_bottom }}%2C{{ demo.location.box_right }}%2C{{ demo.location.box_top }}&amp;layer=mapnik&amp;marker={{ demo.location.marker_lat }}%2C{{ demo.location.marker_lon }}"></iframe>
-      </div>
-      <div class="list-group list-group-flush">
-        <a href="https://www.openstreetmap.org/?mlat={{ demo.location.marker_lat }}&amp;mlon={{ demo.location.marker_lon }}#map=17/{{ demo.location.marker_lat }}/{{ demo.location.marker_lon }}" class="list-group-item" target="_blank">Große Karte öffnen</a>
+  {% if demo.link_set.all %}
+    <div class="col-12">
+      <div class="card">
+        <div class="list-group list-group-horizontal-md text-center">
+          {% for link in demo.link_set.all|slice:":4" %}
+            <a href="{{ link.url }}" class="list-group-item flex-fill" target="_blank">{{ link.title }}</a>
+          {% endfor %}
+        </div>
       </div>
     </div>
-  </div>
-  {% endif %}
-  <div class="col-12 col-md-6">
+    {% endif %}
+  <div class="col-12 col-md-6"> 
     <div class="row">
+      {% if demo.location.lat and demo.location.lon %}
+        <div class="col-12">
+          <div class="card ">
+            <div class="embed-responsive embed-responsive-16by9">
+              <iframe class="embed-responsive-item" src="https://www.openstreetmap.org/export/embed.html?bbox={{ demo.location.box_left }}%2C{{ demo.location.box_bottom }}%2C{{ demo.location.box_right }}%2C{{ demo.location.box_top }}&amp;layer=mapnik&amp;marker={{ demo.location.marker_lat }}%2C{{ demo.location.marker_lon }}"></iframe>
+            </div>
+            <div class="list-group list-group-flush">
+              <a href="https://www.openstreetmap.org/?mlat={{ demo.location.marker_lat }}&amp;mlon={{ demo.location.marker_lon }}#map=17/{{ demo.location.marker_lat }}/{{ demo.location.marker_lon }}" class="list-group-item" target="_blank">Große Karte öffnen</a>
+            </div>
+          </div>
+        </div>
+      {% endif %}
       {% if demo.link_set.all %}
       <div class="col-12">
         <div class="card">
@@ -71,6 +82,10 @@
         </div>
       </div>
       {% endif %}
+    </div>
+  </div>
+  <div class="col-12 col-md-6">
+    <div class="row">
       {% if demo.note %}
       <div class="col-12">
         <div class="card">


### PR DESCRIPTION
Dieser PR fügt folgendes hinzu:
 - Verwendung des Bootstrap Grid auf der Detail seite, (Close #18)
   - Etwas Abstand zwischen einzelnen Tags
   - Karte etwas Kompakter

Grid ansicht auf der Info Seite:
Vorher:
![grafik](https://user-images.githubusercontent.com/34239260/54233305-f989ea00-450c-11e9-8f28-bc2cb845bf47.png)

Nacher:
![grafik](https://user-images.githubusercontent.com/34239260/54233332-07d80600-450d-11e9-92f5-777a48383b3c.png)

