### PR TITLE
 Optimierungen in benutzung der Orga 

### DIFF
--- a/demostat/templates/demostat/components/demo_pagination_bar.html
+++ b/demostat/templates/demostat/components/demo_pagination_bar.html
@@ -2,15 +2,15 @@
   <div class="row">
     <div class="col-4 text-left">
       {% if demo_prev %}
-      <a href="{% url 'demostat:demos_month' demo_prev.date|date:"Y" demo_prev.date|date:"m" %}" class="btn btn-outline-primary">❮ {{ demo_prev.date|date:"F" }} {{ demo_prev.date|date:"Y" }}</a>
+      <a href="{% url 'demostat:demos_month' demo_prev.date|date:"Y" demo_prev.date|date:"m" %}{% if filter_org %}?org={{ filter_org }}{% endif %}" class="btn btn-outline-primary">❮ {{ demo_prev.date|date:"F" }} {{ demo_prev.date|date:"Y" }}</a>
       {% endif %}
     </div>
     <div class="col-4 text-center">
-      <a href="{% url 'demostat:demos_year' date|date:"Y" %}" class="btn btn-outline-primary">{{ date|date:"Y" }}</a>
+      <a href="{% url 'demostat:demos_year' date|date:"Y" %}{% if filter_org %}?org={{ filter_org }}{% endif %}" class="btn btn-outline-primary">{{ date|date:"Y" }}</a>
     </div>
     <div class="col-4 text-right">
       {% if demo_next %}
-      <a href="{% url 'demostat:demos_month' demo_next.date|date:"Y" demo_next.date|date:"m" %}" class="btn btn-outline-primary">{{ demo_next.date|date:"F" }} {{ demo_next.date|date:"Y" }} ❯</a>
+      <a href="{% url 'demostat:demos_month' demo_next.date|date:"Y" demo_next.date|date:"m" %}{% if filter_org %}?org={{ filter_org }}{% endif %}" class="btn btn-outline-primary">{{ demo_next.date|date:"F" }} {{ demo_next.date|date:"Y" }} ❯</a>
       {% endif %}
     </div>
   </div>

--- a/demostat/templates/demostat/demos_list.html
+++ b/demostat/templates/demostat/demos_list.html
@@ -7,6 +7,7 @@
 {% endblock%}
 
 {% block content %}
+{% include "demostat/components/demo_tag_filter_bar.html" %}
 {% regroup demo_list|dictsort:"date" by year as demo_list_date %}
 <section>
   <div class="row">
@@ -16,7 +17,7 @@
         <div class="card-body">
           <h5 class="card-title">{{ year|date:"Y" }}</h5>
           <h6 class="card-subtitle mb-2 text-muted">{{ demos|length}} Demo{% if demos|length > 1 %}s{% endif %}</h6>
-          <a href="{% url 'demostat:demos_year' year|date:"Y" %}" class="btn btn-primary card-link">Mehr Details</a>
+          <a href="{% url 'demostat:demos_year' year|date:"Y" %}{% if filter_org %}?org={{ filter_org }}{% endif %}" class="btn btn-primary card-link">Mehr Details</a>
         </div>
       </div>
     </div>

--- a/demostat/templates/demostat/demos_year_list.html
+++ b/demostat/templates/demostat/demos_year_list.html
@@ -7,6 +7,7 @@
 {% endblock%}
 
 {% block content %}
+{% include "demostat/components/demo_tag_filter_bar.html" %}
 {% regroup demo_list|dictsort:"date" by month as demo_list_date %}
 <section>
   <div class="row">
@@ -16,7 +17,7 @@
         <div class="card-body">
           <h5 class="card-title">{{ month|date:"F" }}</h5>
           <h6 class="card-subtitle mb-2 text-muted">{{ demos|length}} Demo{% if demos|length > 1 %}s{% endif %}</h6>
-          <a href="{% url 'demostat:demos_month' date|date:"Y" month|date:"m" %}" class="btn btn-primary card-link">Mehr Details</a>
+          <a href="{% url 'demostat:demos_month' date|date:"Y" month|date:"m" %}{% if filter_org %}?org={{ filter_org }}{% endif %}" class="btn btn-primary card-link">Mehr Details</a>
         </div>
       </div>
     </div>

--- a/demostat/templates/demostat/organisation_detail.html
+++ b/demostat/templates/demostat/organisation_detail.html
@@ -7,8 +7,15 @@
 {% endblock%}
 
 {% block content %}
+<br>
+{% if organisation.description %}
+  <p>{{ organisation.description }}</p>
+{% endif %}
+{% if organisation.url %}
+  <a class="btn btn-primary" href="{{ organisation.url }}" title="{{ organisation.url }}">Mehr Informationen</a>
+{% endif %}
 {% include "demostat/components/demo_card_list.html" with demo_list=organisation.demo_set.all %}
 <section>
-  <a href="{% url 'demostat:demos' %}" class="btn btn-outline-primary btn-block">weitere Demos</a>
+  <a href="{% url 'demostat:demos' %}?org={{ organisation.slug }}" class="btn btn-outline-primary btn-block">weitere Demos von {{ organisation.name }}</a>
 </section>
 {% endblock %}

--- a/demostat/views.py
+++ b/demostat/views.py
@@ -25,8 +25,16 @@ class IndexView(generic.ListView):
 def demos(request):
     demo_list = get_list_or_404(Demo)
 
+    if 'tag' in request.GET:
+        demo_list = Demo.objects.filter(tags__slug__in=request.GET.getlist('tag'))
+
+    if 'org' in request.GET:
+        demo_list = Demo.objects.filter(organisation__slug=request.GET['org'])
+
     return render(request, 'demostat/demos_list.html', {
-        'demo_list': demo_list
+        'demo_list': demo_list,
+        'filter_tag': sorted(request.GET.getlist('tag')),
+        'filter_org': request.GET.get('org'),
     })
 
 def demos_year(request, date__year):
@@ -34,11 +42,19 @@ def demos_year(request, date__year):
     demo_prev = Demo.objects.filter(date__year__lt=date__year).order_by('date').last()
     demo_next = Demo.objects.filter(date__year__gt=date__year).order_by('date').first()
 
+    if 'tag' in request.GET:
+        demo_list = Demo.objects.filter(tags__slug__in=request.GET.getlist('tag'))
+
+    if 'org' in request.GET:
+        demo_list = Demo.objects.filter(organisation__slug=request.GET['org'])
+
     return render(request, 'demostat/demos_year_list.html', {
         'date': datetime.date(int(date__year), 1, 1),
         'demo_list': demo_list,
         'demo_prev': demo_prev,
         'demo_next': demo_next,
+        'filter_tag': sorted(request.GET.getlist('tag')),
+        'filter_org': request.GET.get('org'),
     })
 
 def demos_month(request, date__year, date__month):


### PR DESCRIPTION
 - Auf der Orga Seite wird nun Beschreibung und Link angezeigt
 - Der button unten wird von "weitere Demos" zu "weitere Demos von <orga-name>" geändert
 - Der Filter (?org=<slug>) greift in der Archiv Ansicht von Anfang an und wird durchgereict

Ref #22 

Neue Orga info Seite:
![Screenshot_2019-03-14 Demos von Fridays For Future Erfurt Demos in Erfurt(1)](https://user-images.githubusercontent.com/34239260/54347973-605fee00-4648-11e9-980d-90713251aa7c.png)