### PR TITLE
Hinzufügen der MySQL Option STRICT_TRANS_TABLES

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ DATABASES = {
         'PASSWORD': '<password>',
         'HOST': 'localhost',
         'PORT': '3306',
+        'OPTIONS':  {
+          'init_command': "SET sql_mode='STRICT_TRANS_TABLES'", # Sicherheitsmaßnahme um das Schreiben von Fehlerhaften Daten zu verhindern https://docs.djangoproject.com/en/2.1/ref/databases/#mysql-sql-mode
+        },
     }
 }
 


### PR DESCRIPTION
> MySQL's Strict Mode fixes many data integrity problems in MySQL, such as data truncation upon insertion, by escalating warnings into errors.
https://docs.djangoproject.com/en/2.1/ref/databases/#mysql-sql-mode

Close #35