### PR TITLE
Anzeigen einer contact E-Mail

### DIFF
--- a/demostat/templates/demostat/about.html
+++ b/demostat/templates/demostat/about.html
@@ -18,6 +18,14 @@
 
   <p>Wer steckt hinter der Demo? Auch das lässt sich ganz einfach herausfinden. Zu jeder Organisation gibt es eine kleine Zusammenfassung mit Links zur Homepage.</p>
 </section>
+{% if CONTACT_EMAIL %}
+<section id="einreichen">
+  <h3>Demo Eintragen</h3>
+    <p>Wenn du eine Demonstration kennst, welche hier noch nicht eingetragen ist, sende uns diese doch bitte an <a href="mailto:{{ CONTACT_EMAIL }}">{{ CONTACT_EMAIL }}</a>!</p>
+
+    <i>In der Zukunft wird es dafür eine Formular auf der Seite geben - das Einreichen via E-Mail ist aktuell nur ein Provisorium.</i>
+</section>
+{% endif %}
 <section>
   <h3>Meta</h3>
   <div class="row">

--- a/demostat/templates/demostat/base.html
+++ b/demostat/templates/demostat/base.html
@@ -29,7 +29,7 @@
               <a class="nav-link" href="{% url 'demostat:about' %}">Über</a>
             </li>
           </ul>
-          <a href="#" class="btn btn-primary">Demo eintragen</a>
+          <a href="/about/#einreichen" class="btn btn-primary">Demo eintragen</a>
         </div>
       </div>
     </nav>

--- a/demostat/views.py
+++ b/demostat/views.py
@@ -35,6 +35,11 @@ def make_context_object(context):
     except:
         pass
 
+    try:
+        s['CONTACT_EMAIL'] = settings.CONTACT_EMAIL
+    except:
+        pass
+
     # https://leafletjs.com/reference-1.4.0.html#tilelayer
     try:
         if settings.DEMOSTAT_LEAFLET['url'] and settings.DEMOSTAT_LEAFLET['attribution'] and settings.DEMOSTAT_LEAFLET['maxZoom']:

--- a/docs/conf.rst
+++ b/docs/conf.rst
@@ -40,3 +40,15 @@ Konfiguriere eine eigene Karten-Kachel-Quelle, z.B. für eine Proxy.
 
 
 Mehr dazu: https://leafletjs.com/reference-1.4.0.html#tilelayer
+
+String `CONTACT_EMAIL`
+----------------------
+
+Diese E-Mail wird auf der `Über Demostat`, gemeinsam mit einem Vermek dass dort Demos eingereicht werden können, angezeigt.
+
+Wenn dieser Parameter nicht gesetzt ist, wird die entpsrechende Sektion auf der Website nicht angezeigt.
+
+::
+
+    CONTACT_EMAIL = "hallo@demostat.de"
+


### PR DESCRIPTION
- Über den Parameter CONTACT_EMAIL kann eine E-Mail hinterlegt werden wo Demonstrationen vorgeschlagen werden können.
- Eine Notiz dass dies nur ein Provisorium ist, ist ebenfalls enthalten
- Dokumentation ist ebenfalls verfasst