### PR TITLE
Filtering and automatic slug in admin UI

### DIFF
--- a/demostat/admin.py
+++ b/demostat/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.utils.html import format_html
 
 # Register your models here.
 from .models import Organisation, Region, Location, Tag, Demo, Link
@@ -35,6 +36,7 @@ class DemoAdmin(admin.ModelAdmin):
 class LinkAdmin(admin.ModelAdmin):
     list_display = (
             'title',
+            'fqdn',
             'demo_name',
             'demo_date',
         )
@@ -52,6 +54,9 @@ class LinkAdmin(admin.ModelAdmin):
 
     def demo_date(self, obj):
         return obj.demo.date
+
+    def fqdn(self, obj):
+        return format_html("<a href='{}'>{}</a>", obj.url, obj.fqdn)
 
 @admin.register(Location)
 class LocationAdmin(admin.ModelAdmin):
@@ -73,9 +78,16 @@ class LocationAdmin(admin.ModelAdmin):
 class OrganisationAdmin(admin.ModelAdmin):
     list_display = (
             'name',
+            'url_fqdn',
         )
 
     prepopulated_fields = {"slug": ("name",)}
+
+    def url_fqdn(self, obj):
+        if not obj.url_fqdn:
+            return None
+
+        return format_html("<a href='{}'>{}</a>", obj.url, obj.url_fqdn)
 
 @admin.register(Region)
 class RegionAdmin(admin.ModelAdmin):

--- a/demostat/admin.py
+++ b/demostat/admin.py
@@ -5,19 +5,100 @@ from .models import Organisation, Region, Location, Tag, Demo, Link
 
 @admin.register(Demo)
 class DemoAdmin(admin.ModelAdmin):
+    search_fields = (
+            'slug',
+            'title',
+            'location__name',
+            'organisation__name',
+            'description',
+            'note',
+            'tags',
+        )
+
     prepopulated_fields = {"slug": ("title",)}
+
+    date_hierarchy = 'date'
+
+    list_display = (
+            'title',
+            'date',
+            'location'
+        )
+
+    list_filter = (
+            ('location', admin.RelatedOnlyFieldListFilter),
+            ('tags', admin.RelatedOnlyFieldListFilter),
+            ('organisation', admin.RelatedOnlyFieldListFilter),
+        )
+
+@admin.register(Link)
+class LinkAdmin(admin.ModelAdmin):
+    list_display = (
+            'title',
+            'demo_name',
+            'demo_date',
+        )
+
+    search_fields = (
+            'title',
+            'url',
+            'demo__title'
+        )
+
+    date_hierarchy = 'demo__date'
+
+    def demo_name(self, obj):
+        return obj.demo.title
+
+    def demo_date(self, obj):
+        return obj.demo.date
+
+@admin.register(Location)
+class LocationAdmin(admin.ModelAdmin):
+    list_display = (
+            'name',
+            'region'
+        )
+
+    list_filter = (
+            ('region', admin.RelatedOnlyFieldListFilter),
+        )
+
+    search_fields = (
+            'name',
+            'region__name',
+        )
 
 @admin.register(Organisation)
 class OrganisationAdmin(admin.ModelAdmin):
+    list_display = (
+            'name',
+        )
+
     prepopulated_fields = {"slug": ("name",)}
 
 @admin.register(Region)
 class RegionAdmin(admin.ModelAdmin):
+    list_display = (
+            'name',
+            'group',
+        )
+
+    list_filter = (
+            ('group', admin.RelatedOnlyFieldListFilter),
+        )
+
     prepopulated_fields = {'slug': ('name',)}
+
+    search_fields = (
+            'name',
+            'group',
+        )
 
 @admin.register(Tag)
 class TagAdmin(admin.ModelAdmin):
     prepopulated_fields = {'slug': ('name',)}
 
-admin.site.register(Location)
-admin.site.register(Link)
+    search_fields = (
+            'name',
+        )

--- a/demostat/admin.py
+++ b/demostat/admin.py
@@ -3,9 +3,21 @@ from django.contrib import admin
 # Register your models here.
 from .models import Organisation, Region, Location, Tag, Demo, Link
 
-admin.site.register(Organisation)
-admin.site.register(Region)
+@admin.register(Demo)
+class DemoAdmin(admin.ModelAdmin):
+    prepopulated_fields = {"slug": ("title",)}
+
+@admin.register(Organisation)
+class OrganisationAdmin(admin.ModelAdmin):
+    prepopulated_fields = {"slug": ("name",)}
+
+@admin.register(Region)
+class RegionAdmin(admin.ModelAdmin):
+    prepopulated_fields = {'slug': ('name',)}
+
+@admin.register(Tag)
+class TagAdmin(admin.ModelAdmin):
+    prepopulated_fields = {'slug': ('name',)}
+
 admin.site.register(Location)
-admin.site.register(Tag)
-admin.site.register(Demo)
 admin.site.register(Link)

--- a/demostat/models.py
+++ b/demostat/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.utils import timezone
+from urllib.parse import urlparse
 
 import decimal
 import datetime
@@ -16,6 +17,13 @@ class Organisation(models.Model):
 
     def __str__(self):
         return self.name
+
+    @property
+    def url_fqdn(self):
+        if not self.url:
+            return None
+
+        return urlparse(self.url).hostname.replace('www.','')
 
 class Region(models.Model):
     """
@@ -182,3 +190,7 @@ class Link(models.Model):
 
     def __str__(self):
         return str(self.demo) + '; ' + self.title
+
+    @property
+    def fqdn(self):
+        return urlparse(self.url).hostname.replace('www.','')


### PR DESCRIPTION
- Auto populate slug fields in admin ui (c2de9a0)
- Add filtering and serach to admin site (28c1deb)
  - Group by date when applicable
  - Filter by related fields
  - May not scale unlimited for now it seems a good balance
- Add FQDN to Link and Organisation (dd89b60)
  - Display the FQDN (e.g. https://erfurt.demostat.de/d/25 ->
    erfurt.emostat.de) and link to the whole URL in the admin ui.
  - Possible use in the main UI

See the respective commit messages for further details.
